### PR TITLE
v0.3.2: refactor: rename executable from mcp-ts to mcp-server-tree-sitter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,4 +111,4 @@ jobs:
     - name: Install and verify
       run: |
         python -m pip install dist/*.whl
-        mcp-ts --help
+        mcp-server-tree-sitter --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Test wheel
       run: |
         python -m pip install dist/*.whl
-        mcp-ts --help
+        mcp-server-tree-sitter --help
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -101,6 +101,32 @@ Alternatively, you can manually configure Claude Desktop:
 
 The MCP tools icon (hammer) will appear in Claude Desktop's interface once you have properly configured at least one MCP server. You can then access the `tree_sitter` server's functionality by clicking on this icon.
 
+### Configuring with Released Version
+
+If you've installed the package from PyPI (released version) rather than cloning the repository, use the following configuration for Claude Desktop:
+
+1. Open your Claude Desktop configuration file (same location as above).
+
+2. Add the tree-sitter server to the `mcpServers` section:
+
+   ```json
+   {
+       "mcpServers": {
+           "tree_sitter": {
+               "command": "uvx",
+               "args": [
+                   "--directory", "/ABSOLUTE/PATH/TO/YOUR/PROJECT",
+                   "mcp-server-tree-sitter"
+               ]
+           }
+       }
+   }
+   ```
+
+3. Save the file and restart Claude Desktop.
+
+This method uses `uvx` to run the installed PyPI package directly, which is the recommended approach for the released version. The server doesn't require any additional parameters to run in its basic configuration.
+
 ## State Persistence
 
 The MCP Tree-sitter Server maintains state between invocations. This means:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-tree-sitter"
-version = "0.3.1"
+version = "0.3.2"
 description = "MCP Server for Tree-sitter code analysis"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -46,7 +46,7 @@ languages = [
 "Bug Tracker" = "https://github.com/wrale/mcp-server-tree-sitter/issues"
 
 [project.scripts]
-mcp-ts = "mcp_server_tree_sitter.server:main"
+mcp-server-tree-sitter = "mcp_server_tree_sitter.server:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mcp_server_tree_sitter"]


### PR DESCRIPTION
Rename the main executable from mcp-ts to mcp-server-tree-sitter to match the package name for better discoverability and intuitive usage. This change:

- Updates the entry point in pyproject.toml
- Updates CI/CD workflows to verify the new executable name
- Adds documentation for using the renamed executable with uvx