### PR TITLE
config: env-var precedence tests and fix

### DIFF
--- a/src/mcp_server_tree_sitter/config.py
+++ b/src/mcp_server_tree_sitter/config.py
@@ -112,6 +112,47 @@ class ServerConfig(BaseModel):
             if log_level is not None:
                 config.log_level = log_level
 
+        # ------------------------------------------------------------------
+        # Generic 12-factor env support: MCP_TS_<SECTION>__<KEY>=VALUE
+        # e.g. MCP_TS_CACHE__MAX_SIZE_MB=512
+        # ------------------------------------------------------------------
+        for env_key, env_val in os.environ.items():
+            if not env_key.startswith("MCP_TS_") or "__" not in env_key:
+                continue
+
+            raw_key = env_key[len("MCP_TS_") :]
+            section, key = raw_key.split("__", 1)
+            section = section.lower()
+            key = key.lower()
+
+            # Try nested section first
+            if hasattr(config, section):
+                section_obj = getattr(config, section)
+                if hasattr(section_obj, key):
+                    current_val = getattr(section_obj, key)
+
+                    # Convert to the existing field type
+                    if isinstance(current_val, bool):
+                        converted_val = str(env_val).lower() == "true"
+                    elif isinstance(current_val, int):
+                        try:
+                            converted_val = int(env_val)
+                        except ValueError:
+                            # Skip invalid integer
+                            continue
+                    elif isinstance(current_val, list):
+                        # Comma-separated list
+                        converted_val = [item.strip() for item in env_val.split(",") if item.strip()]
+                    else:
+                        converted_val = env_val
+
+                    setattr(section_obj, key, converted_val)
+                    continue  # done; go to next env var
+
+            # Fallback: top-level attribute with single key
+            if hasattr(config, section):
+                setattr(config, section, env_val)
+
         return config
 
 
@@ -120,7 +161,8 @@ class ConfigurationManager:
 
     def __init__(self, initial_config: Optional[ServerConfig] = None):
         """Initialize with optional initial configuration."""
-        self._config = initial_config or ServerConfig()
+        # Load defaults overridden by environment variables (12-factor style)
+        self._config = initial_config or ServerConfig.from_env()
         self._logger = logging.getLogger(__name__)
 
     def get_config(self) -> ServerConfig:

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -87,3 +87,30 @@ def test_config_manager_to_dict():
     assert "security" in config_dict
     assert "language" in config_dict
     assert config_dict["cache"]["max_size_mb"] == 100
+def test_env_overrides_defaults(monkeypatch):
+    """Environment variables should override hard-coded defaults."""
+    monkeypatch.setenv("MCP_TS_CACHE__MAX_SIZE_MB", "512")
+
+    from mcp_server_tree_sitter.config import ConfigurationManager
+
+    mgr = ConfigurationManager()
+    cfg = mgr.get_config()
+
+    assert cfg.cache.max_size_mb == 512
+    # ensure other defaults stay intact
+    assert cfg.security.max_file_size_mb == 5
+    assert cfg.language.default_max_depth == 5
+
+
+def test_env_overrides_yaml(temp_yaml_file, monkeypatch):
+    """Environment variables should take precedence over YAML values."""
+    # YAML sets 256; env var must win with 1024
+    monkeypatch.setenv("MCP_TS_CACHE__MAX_SIZE_MB", "1024")
+
+    from mcp_server_tree_sitter.config import ConfigurationManager
+
+    mgr = ConfigurationManager()
+    mgr.load_from_file(temp_yaml_file)
+    cfg = mgr.get_config()
+
+    assert cfg.cache.max_size_mb == 1024


### PR DESCRIPTION
Tests:
- Introduce test_env_overrides_defaults: verify that MCP_TS_CACHE__MAX_SIZE_MB overrides the hard-coded default cache size while leaving other defaults unchanged.
- Introduce test_env_overrides_yaml: ensure that an environment variable takes precedence over a YAML file’s cache setting when loaded.

These tests guard against regressions in ConfigurationManager’s environment-variable-first lookup logic.

Fix:
- Introduce `ServerConfig.from_env()` to scan for `MCP_TS_<SECTION>__<KEY>=VALUE`
- Parse and convert values to their native types (bool, int, list, string)
- Update `ConfigurationManager.__init__` to call `ServerConfig.from_env()` instead of bare defaults
- Preserve fallback for single-key top-level attributes when no nested match is found

This commit resolves issue #11