### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides code analysis capabilities using tree-sitter, designed to give Claude intelligent access to codebases with appropriate context management.
 
+<a href="https://glama.ai/mcp/servers/@wrale/mcp-server-tree-sitter">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@wrale/mcp-server-tree-sitter/badge" alt="mcp-server-tree-sitter MCP server" />
+</a>
+
 ## Features
 
 - 🔍 **Flexible Exploration**: Examine code at multiple levels of granularity


### PR DESCRIPTION
This PR adds a badge for the [mcp-server-tree-sitter](https://glama.ai/mcp/servers/@wrale/mcp-server-tree-sitter) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@wrale/mcp-server-tree-sitter">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@wrale/mcp-server-tree-sitter/badge" alt="mcp-server-tree-sitter MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.