### PR TITLE
fix: Correct debug flag ordering and log level consistency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-tree-sitter"
-version = "0.5.0"
+version = "0.5.1"
 description = "MCP Server for Tree-sitter code analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/check_logging.sh
+++ b/scripts/check_logging.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# check_logging.sh - Script to spot check implementation patterns
-
-grep -r ${1} . --exclude-dir=.venv --exclude-dir=.git --exclude-dir=./diagnostic_results --exclude-dir=./.pytest_cache --exclude-dir=./.ruff_cache --exclude-dir=./tests/__pycache__ --exclude=./.gitignore --exclude=./TODO.md --exclude=./FEATURES.md

--- a/scripts/implementation-search.sh
+++ b/scripts/implementation-search.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# implementation-search.sh - Script to spot check implementation patterns
+
+# Enable strict mode
+set -euo pipefail
+
+# Check if search term is provided
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <search_term>"
+    exit 1
+fi
+
+# Directories to exclude
+EXCLUDE_DIRS=(
+    ".venv"
+    ".git"
+    "./diagnostic_results"
+    "./.pytest_cache"
+    "./.ruff_cache"
+    "./.mypy_cache"
+    "./tests/__pycache__"
+    "./__pycache__"
+    "./src/mcp_server_tree_sitter/__pycache__"
+    "./src/*/bootstrap/__pycache__"
+    "./src/*/__pycache__"
+)
+
+# Files to exclude
+EXCLUDE_FILES=(
+    "./.gitignore"
+    "./TODO.md"
+    "./FEATURES.md"
+)
+
+# Build exclude arguments for grep
+EXCLUDE_ARGS=""
+for dir in "${EXCLUDE_DIRS[@]}"; do
+    EXCLUDE_ARGS+="--exclude-dir=${dir} "
+done
+
+for file in "${EXCLUDE_FILES[@]}"; do
+    EXCLUDE_ARGS+="--exclude=${file} "
+done
+
+# Run grep with all exclusions
+grep -r "${1}" . ${EXCLUDE_ARGS} --binary-files=without-match

--- a/src/mcp_server_tree_sitter/__main__.py
+++ b/src/mcp_server_tree_sitter/__main__.py
@@ -37,10 +37,10 @@ def main() -> int:
 
     # Set up logging level
     if args.debug:
-        # Override with command-line debug flag
-        update_log_levels("DEBUG")
-        # Set environment variable for consistency with other modules
+        # Set environment variable first for consistency
         os.environ["MCP_TS_LOG_LEVEL"] = "DEBUG"
+        # Then update log levels
+        update_log_levels("DEBUG")
         logger.debug("Debug logging enabled")
 
     # Load configuration

--- a/src/mcp_server_tree_sitter/bootstrap/logging_bootstrap.py
+++ b/src/mcp_server_tree_sitter/bootstrap/logging_bootstrap.py
@@ -54,6 +54,14 @@ def configure_root_logger() -> None:
     # Ensure propagation is preserved
     pkg_logger.propagate = True
 
+    # Ensure all existing loggers' handlers are synchronized
+    for name in logging.root.manager.loggerDict:
+        if name.startswith("mcp_server_tree_sitter"):
+            logger = logging.getLogger(name)
+            # Only synchronize handler levels, don't set logger level
+            for handler in logger.handlers:
+                handler.setLevel(logger.getEffectiveLevel())
+
 
 def update_log_levels(level_name: Union[str, int]) -> None:
     """
@@ -78,6 +86,13 @@ def update_log_levels(level_name: Union[str, int]) -> None:
 
     # Update all handlers on the root package logger
     for handler in pkg_logger.handlers:
+        handler.setLevel(level_value)
+
+    # Also update the root logger for consistency - this helps with debug flag handling
+    # when the module is already imported
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level_value)
+    for handler in root_logger.handlers:
         handler.setLevel(level_value)
 
     # Synchronize handler levels with their logger's effective level

--- a/src/mcp_server_tree_sitter/config.py
+++ b/src/mcp_server_tree_sitter/config.py
@@ -146,7 +146,7 @@ def update_config_from_env(config: ServerConfig) -> None:
                 orig_value = getattr(config, setting)
                 new_value = _convert_value(env_value, orig_value)
                 setattr(config, setting, new_value)
-                logger.info(f"Applied environment variable {env_name} to {setting}: {orig_value} -> {new_value}")
+                logger.debug(f"Applied environment variable {env_name} to {setting}: {orig_value} -> {new_value}")
             else:
                 logger.warning(f"Unknown top-level setting in environment variable {env_name}: {setting}")
         elif hasattr(config, section):
@@ -157,7 +157,7 @@ def update_config_from_env(config: ServerConfig) -> None:
                 orig_value = getattr(section_obj, setting)
                 new_value = _convert_value(env_value, orig_value)
                 setattr(section_obj, setting, new_value)
-                logger.info(
+                logger.debug(
                     f"Applied environment variable {env_name} to {section}.{setting}: {orig_value} -> {new_value}"
                 )
             else:
@@ -321,7 +321,7 @@ class ConfigurationManager:
 
                 # Update logging configuration using centralized bootstrap module
                 update_log_levels(self._config.log_level)
-                self._logger.info(f"Applied log level {self._config.log_level} to mcp_server_tree_sitter loggers")
+                self._logger.debug(f"Applied log level {self._config.log_level} to mcp_server_tree_sitter loggers")
 
                 self._logger.info("Applied configuration to dependencies")
             except (ImportError, AttributeError) as e:

--- a/src/mcp_server_tree_sitter/context.py
+++ b/src/mcp_server_tree_sitter/context.py
@@ -115,7 +115,7 @@ class ServerContext:
 
             # Apply log level using centralized bootstrap function
             update_log_levels(log_level)
-            logger.info(f"Applied log level {log_level} to mcp_server_tree_sitter loggers")
+            logger.debug(f"Applied log level {log_level} to mcp_server_tree_sitter loggers")
 
         # Return current config as dict
         return self.config_manager.to_dict()

--- a/src/mcp_server_tree_sitter/server.py
+++ b/src/mcp_server_tree_sitter/server.py
@@ -84,7 +84,7 @@ def configure_with_context(
 
         # Apply log level using already imported update_log_levels
         update_log_levels(log_level)
-        logger.info(f"Applied log level {log_level} to mcp_server_tree_sitter loggers")
+        logger.debug(f"Applied log level {log_level} to mcp_server_tree_sitter loggers")
 
     # Get final configuration
     config = config_manager.get_config()
@@ -128,6 +128,9 @@ def main() -> None:
 
     # Set up debug logging if requested
     if args.debug:
+        # Set environment variable first for consistency
+        os.environ["MCP_TS_LOG_LEVEL"] = "DEBUG"
+        # Then update log levels
         update_log_levels("DEBUG")
         logger.debug("Debug logging enabled")
 

--- a/tests/test_debug_flag.py
+++ b/tests/test_debug_flag.py
@@ -1,0 +1,328 @@
+"""Tests for debug flag behavior and environment variable processing."""
+
+import io
+import logging
+import os
+
+import pytest
+
+from mcp_server_tree_sitter.bootstrap import update_log_levels
+from mcp_server_tree_sitter.bootstrap.logging_bootstrap import get_log_level_from_env
+
+
+def test_debug_flag_with_preexisting_env():
+    """Test that debug flag works correctly with pre-existing environment variables.
+
+    This test simulates the real-world scenario where the logging is configured
+    at import time, but the debug flag is processed later. In this case, the
+    debug flag should still trigger a reconfiguration of logging levels.
+    """
+    # Save original environment and logger state
+    original_env = os.environ.get("MCP_TS_LOG_LEVEL")
+
+    # Get the root package logger
+    pkg_logger = logging.getLogger("mcp_server_tree_sitter")
+    original_level = pkg_logger.level
+
+    # Create a clean test environment
+    if "MCP_TS_LOG_LEVEL" in os.environ:
+        del os.environ["MCP_TS_LOG_LEVEL"]
+
+    # Set logger level to INFO explicitly
+    pkg_logger.setLevel(logging.INFO)
+
+    # Create a test handler to verify levels change
+    test_handler = logging.StreamHandler()
+    test_handler.setLevel(logging.INFO)
+    pkg_logger.addHandler(test_handler)
+
+    try:
+        # Simulate the debug flag processing
+        # First verify we're starting at INFO level
+        assert pkg_logger.level == logging.INFO, "Logger should start at INFO level"
+        assert test_handler.level == logging.INFO, "Handler should start at INFO level"
+
+        # Now process the debug flag (this is what happens in main())
+        os.environ["MCP_TS_LOG_LEVEL"] = "DEBUG"
+        update_log_levels("DEBUG")
+
+        # Verify the change was applied
+        assert pkg_logger.level == logging.DEBUG, "Logger level should be changed to DEBUG"
+        assert test_handler.level == logging.DEBUG, "Handler level should be changed to DEBUG"
+
+        # Verify that new loggers created after updating will inherit the correct level
+        new_logger = logging.getLogger("mcp_server_tree_sitter.test.new_module")
+        assert new_logger.getEffectiveLevel() == logging.DEBUG, "New loggers should inherit DEBUG level"
+
+    finally:
+        # Cleanup
+        pkg_logger.removeHandler(test_handler)
+
+        # Restore original environment
+        if original_env is not None:
+            os.environ["MCP_TS_LOG_LEVEL"] = original_env
+        else:
+            if "MCP_TS_LOG_LEVEL" in os.environ:
+                del os.environ["MCP_TS_LOG_LEVEL"]
+
+        # Restore logger state
+        pkg_logger.setLevel(original_level)
+
+
+def test_update_log_levels_reconfigures_root_logger():
+    """Test that update_log_levels also updates the root logger.
+
+    This tests the enhanced implementation that reconfigures the root
+    logger in addition to the package logger, which helps with debug
+    flag handling when a module is already imported.
+    """
+    # Save original logger states
+    root_logger = logging.getLogger()
+    pkg_logger = logging.getLogger("mcp_server_tree_sitter")
+    original_root_level = root_logger.level
+    original_pkg_level = pkg_logger.level
+
+    # Create handlers for testing
+    root_handler = logging.StreamHandler()
+    root_handler.setLevel(logging.INFO)
+    root_logger.addHandler(root_handler)
+
+    pkg_handler = logging.StreamHandler()
+    pkg_handler.setLevel(logging.INFO)
+    pkg_logger.addHandler(pkg_handler)
+
+    try:
+        # Set loggers to INFO level
+        root_logger.setLevel(logging.INFO)
+        pkg_logger.setLevel(logging.INFO)
+
+        # Verify initial levels
+        assert root_logger.level == logging.INFO, "Root logger should start at INFO level"
+        assert pkg_logger.level == logging.INFO, "Package logger should start at INFO level"
+        assert root_handler.level == logging.INFO, "Root handler should start at INFO level"
+        assert pkg_handler.level == logging.INFO, "Package handler should start at INFO level"
+
+        # Call update_log_levels with DEBUG
+        update_log_levels("DEBUG")
+
+        # Verify all loggers and handlers are updated
+        assert root_logger.level == logging.DEBUG, "Root logger should be updated to DEBUG level"
+        assert pkg_logger.level == logging.DEBUG, "Package logger should be updated to DEBUG level"
+        assert root_handler.level == logging.DEBUG, "Root handler should be updated to DEBUG level"
+        assert pkg_handler.level == logging.DEBUG, "Package handler should be updated to DEBUG level"
+
+        # Test with a new child logger
+        child_logger = logging.getLogger("mcp_server_tree_sitter.test.child")
+        assert child_logger.getEffectiveLevel() == logging.DEBUG, "Child logger should inherit DEBUG level from parent"
+
+    finally:
+        # Clean up
+        root_logger.removeHandler(root_handler)
+        pkg_logger.removeHandler(pkg_handler)
+
+        # Restore original levels
+        root_logger.setLevel(original_root_level)
+        pkg_logger.setLevel(original_pkg_level)
+
+
+def test_environment_variable_updates_log_level():
+    """Test that setting MCP_TS_LOG_LEVEL changes the logging level correctly."""
+    # Save original environment and logger state
+    original_env = os.environ.get("MCP_TS_LOG_LEVEL")
+
+    # Get the root package logger
+    pkg_logger = logging.getLogger("mcp_server_tree_sitter")
+    original_level = pkg_logger.level
+
+    try:
+        # First test with DEBUG level
+        os.environ["MCP_TS_LOG_LEVEL"] = "DEBUG"
+
+        # Verify the get_log_level_from_env function returns DEBUG
+        level = get_log_level_from_env()
+        assert level == logging.DEBUG, f"Expected DEBUG level but got {level}"
+
+        # Update log levels and verify the logger is set to DEBUG
+        update_log_levels("DEBUG")
+        assert pkg_logger.level == logging.DEBUG, f"Logger level should be DEBUG but was {pkg_logger.level}"
+
+        # Check handler levels are synchronized
+        for handler in pkg_logger.handlers:
+            assert handler.level == logging.DEBUG, f"Handler level should be DEBUG but was {handler.level}"
+
+        # Next test with INFO level
+        os.environ["MCP_TS_LOG_LEVEL"] = "INFO"
+
+        # Verify the get_log_level_from_env function returns INFO
+        level = get_log_level_from_env()
+        assert level == logging.INFO, f"Expected INFO level but got {level}"
+
+        # Update log levels and verify the logger is set to INFO
+        update_log_levels("INFO")
+        assert pkg_logger.level == logging.INFO, f"Logger level should be INFO but was {pkg_logger.level}"
+
+        # Check handler levels are synchronized
+        for handler in pkg_logger.handlers:
+            assert handler.level == logging.INFO, f"Handler level should be INFO but was {handler.level}"
+
+    finally:
+        # Restore original environment
+        if original_env is not None:
+            os.environ["MCP_TS_LOG_LEVEL"] = original_env
+        else:
+            if "MCP_TS_LOG_LEVEL" in os.environ:
+                del os.environ["MCP_TS_LOG_LEVEL"]
+
+        # Restore logger state
+        pkg_logger.setLevel(original_level)
+
+
+def test_configure_root_logger_syncs_handlers():
+    """Test that configure_root_logger synchronizes handler levels for existing loggers."""
+    from mcp_server_tree_sitter.bootstrap.logging_bootstrap import configure_root_logger
+
+    # Save original environment and logger state
+    original_env = os.environ.get("MCP_TS_LOG_LEVEL")
+
+    # Create a test logger in the package hierarchy
+    test_logger = logging.getLogger("mcp_server_tree_sitter.test.debug_flag")
+    original_test_level = test_logger.level
+
+    # Get the root package logger
+    pkg_logger = logging.getLogger("mcp_server_tree_sitter")
+    original_pkg_level = pkg_logger.level
+
+    # Create handlers with different levels
+    debug_handler = logging.StreamHandler()
+    debug_handler.setLevel(logging.DEBUG)
+
+    info_handler = logging.StreamHandler()
+    info_handler.setLevel(logging.INFO)
+
+    # Add handlers to the test logger
+    test_logger.addHandler(debug_handler)
+    test_logger.addHandler(info_handler)
+
+    try:
+        # Set environment variable to DEBUG
+        os.environ["MCP_TS_LOG_LEVEL"] = "DEBUG"
+
+        # Call configure_root_logger
+        configure_root_logger()
+
+        # Verify the root package logger is set to DEBUG
+        assert pkg_logger.level == logging.DEBUG, (
+            f"Root package logger level should be DEBUG but was {pkg_logger.level}"
+        )
+
+        # Verify child logger still has its original level (should not be explicitly set)
+        assert test_logger.level == original_test_level, (
+            "Child logger level should not be changed by configure_root_logger"
+        )
+
+        # Verify child logger's effective level is inherited from root package logger
+        assert test_logger.getEffectiveLevel() == logging.DEBUG, (
+            f"Child logger effective level should be DEBUG but was {test_logger.getEffectiveLevel()}"
+        )
+
+        # Verify all handlers of the test logger are synchronized to DEBUG
+        for handler in test_logger.handlers:
+            assert handler.level == logging.DEBUG, f"Handler level should be DEBUG but was {handler.level}"
+
+    finally:
+        # Clean up
+        test_logger.removeHandler(debug_handler)
+        test_logger.removeHandler(info_handler)
+
+        # Restore original environment
+        if original_env is not None:
+            os.environ["MCP_TS_LOG_LEVEL"] = original_env
+        else:
+            if "MCP_TS_LOG_LEVEL" in os.environ:
+                del os.environ["MCP_TS_LOG_LEVEL"]
+
+        # Restore logger state
+        test_logger.setLevel(original_test_level)
+        pkg_logger.setLevel(original_pkg_level)
+
+
+def test_log_message_levels():
+    """Test that log messages about environment variables use the DEBUG level."""
+    # Save original environment state
+    original_env = {}
+    for key in list(os.environ.keys()):
+        if key.startswith("MCP_TS_"):
+            original_env[key] = os.environ[key]
+            del os.environ[key]
+
+    try:
+        # Test variable for configuration
+        os.environ["MCP_TS_CACHE_MAX_SIZE_MB"] = "256"
+
+        # Create a StringIO to capture log output
+        log_output = io.StringIO()
+
+        # Create a handler that writes to our StringIO
+        handler = logging.StreamHandler(log_output)
+        handler.setLevel(logging.DEBUG)
+        formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+        handler.setFormatter(formatter)
+
+        # Add the handler to the root logger
+        root_logger = logging.getLogger()
+        root_logger.addHandler(handler)
+
+        # Save the original log level
+        original_level = root_logger.level
+
+        # Set the log level to DEBUG to capture all messages
+        root_logger.setLevel(logging.DEBUG)
+
+        try:
+            # Import config to trigger environment variable processing
+            from mcp_server_tree_sitter.config import ServerConfig
+
+            # Create a new config instance to trigger environment variable processing
+            # Variable is intentionally used to trigger processing
+            _ = ServerConfig()
+
+            # Get the output
+            log_content = log_output.getvalue()
+
+            # Check for environment variable application messages
+            env_messages = [line for line in log_content.splitlines() if "Applied environment variable" in line]
+
+            # Verify that these messages use DEBUG level, not INFO
+            for msg in env_messages:
+                assert msg.startswith("DEBUG:"), f"Environment variable message should use DEBUG level but found: {msg}"
+
+            # Check if there are any environment variable messages at INFO level
+            info_env_messages = [
+                line
+                for line in log_content.splitlines()
+                if "Applied environment variable" in line and line.startswith("INFO:")
+            ]
+
+            assert not info_env_messages, (
+                f"No environment variable messages should use INFO level, but found: {info_env_messages}"
+            )
+
+        finally:
+            # Restore original log level
+            root_logger.setLevel(original_level)
+
+            # Remove our handler
+            root_logger.removeHandler(handler)
+
+    finally:
+        # Restore original environment
+        for key in list(os.environ.keys()):
+            if key.startswith("MCP_TS_"):
+                del os.environ[key]
+
+        for key, value in original_env.items():
+            os.environ[key] = value
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -122,8 +122,11 @@ def test_configure_with_context_log_level(mock_container):
         mock_root_logger = MagicMock()
         mock_get_logger.return_value = mock_root_logger
 
-        # All logger calls should return the same mock root logger
-        mock_get_logger.side_effect = lambda name: mock_root_logger
+        # Set up side effect to handle both cases: with or without a name
+        def get_logger_side_effect(*args, **kwargs):
+            return mock_root_logger
+
+        mock_get_logger.side_effect = get_logger_side_effect
 
         # Mock logging.root.manager.loggerDict
         with patch(


### PR DESCRIPTION
- Fix order of operations in CLI processing for debug flag
- Change log messages for environment variables from INFO to DEBUG
- Add handler synchronization for existing loggers
- Fix unused variable in test_debug_flag.py

Addresses the issues outlined in LOGGING-FIX-TODO.md, ensuring that the MCP_TS_LOG_LEVEL environment variable is properly set before log levels are updated.

Bump to 0.5.1