### PR TITLE
fix: register csharp language

### DIFF
--- a/src/mcp_server_tree_sitter/language/registry.py
+++ b/src/mcp_server_tree_sitter/language/registry.py
@@ -40,7 +40,7 @@ class LanguageRegistry:
             "cc": "cpp",
             "h": "c",
             "hpp": "cpp",
-            "cs": "c_sharp",
+            "cs": "csharp",
             "php": "php",
             "scala": "scala",
             "swift": "swift",


### PR DESCRIPTION
 Language c_sharp not available via tree-sitter-language-pack: Could not find language library for c_sharp